### PR TITLE
feat: Add baseURI importStyle.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,12 +5,13 @@ const template = require('@babel/template').default;
 const inherits = require('@babel/plugin-syntax-import-meta').default;
 
 const importStyles = {
-	amd: "new URL((typeof process !== 'undefined' && process.versions && process.versions.node ? 'file:' : '') + module.uri).href",
-	cjs: "new (typeof URL !== 'undefined' ? URL : require('ur'+'l').URL)((process.browser ? '' : 'file:') + __filename, process.browser && document.baseURI).href",
+	amd: 'new URL(module.uri).href',
+	cjs: 'new URL(__filename, document.baseURI).href',
 	esm: 'import.meta.url',
-	iife: "typeof document !== 'undefined' ? document.currentScript && document.currentScript.src || document.baseURI : new (typeof URL !== 'undefined' ? URL : require('ur'+'l').URL)('file:' + __filename).href",
-	umd: "typeof document !== 'undefined' ? document.currentScript && document.currentScript.src || document.baseURI : new (typeof URL !== 'undefined' ? URL : require('ur'+'l').URL)('file:' + __filename).href",
-	system: 'module.meta.url'
+	iife: 'document.currentScript && document.currentScript.src || document.baseURI',
+	umd: 'document.currentScript && document.currentScript.src || document.baseURI',
+	system: 'module.meta.url',
+	baseURI: 'document.baseURI'
 };
 
 module.exports = () => ({

--- a/test.js
+++ b/test.js
@@ -90,7 +90,7 @@ test('without import.meta', babelTest, {
 
 test('importStyle amd', babelTest, {
 	source: 'console.log(import.meta.url);',
-	result: "const importMeta={url:new URL('./file.js',new URL((typeof process!=='undefined'&&process.versions&&process.versions.node?'file:':'')+module.uri).href).href};console.log(importMeta.url);",
+	result: "const importMeta={url:new URL('./file.js',new URL(module.uri).href).href};console.log(importMeta.url);",
 	mappings: {
 		[path.resolve(__dirname, 'fake-dir')]: '/testing'
 	},
@@ -99,7 +99,7 @@ test('importStyle amd', babelTest, {
 
 test('importStyle cjs', babelTest, {
 	source: 'console.log(import.meta.url);',
-	result: "const importMeta={url:new URL('./file.js',new(typeof URL!=='undefined'?URL:require('ur'+'l').URL)((process.browser?'':'file:')+__filename,process.browser&&document.baseURI).href).href};console.log(importMeta.url);",
+	result: "const importMeta={url:new URL('./file.js',new URL(__filename,document.baseURI).href).href};console.log(importMeta.url);",
 	importStyle: 'cjs'
 });
 
@@ -111,13 +111,19 @@ test('importStyle esm', babelTest, {
 
 test('importStyle iife', babelTest, {
 	source: 'console.log(import.meta.url);',
-	result: "const importMeta={url:new URL('./file.js',typeof document!=='undefined'?document.currentScript&&document.currentScript.src||document.baseURI:new(typeof URL!=='undefined'?URL:require('ur'+'l').URL)('file:'+__filename).href).href};console.log(importMeta.url);",
+	result: "const importMeta={url:new URL('./file.js',document.currentScript&&document.currentScript.src||document.baseURI).href};console.log(importMeta.url);",
 	importStyle: 'iife'
+});
+
+test('importStyle baseURI', babelTest, {
+	source: 'console.log(import.meta.url);',
+	result: "const importMeta={url:new URL('./file.js',document.baseURI).href};console.log(importMeta.url);",
+	importStyle: 'baseURI'
 });
 
 test('importStyle umd', babelTest, {
 	source: 'console.log(import.meta.url);',
-	result: "const importMeta={url:new URL('./file.js',typeof document!=='undefined'?document.currentScript&&document.currentScript.src||document.baseURI:new(typeof URL!=='undefined'?URL:require('ur'+'l').URL)('file:'+__filename).href).href};console.log(importMeta.url);",
+	result: "const importMeta={url:new URL('./file.js',document.currentScript&&document.currentScript.src||document.baseURI).href};console.log(importMeta.url);",
 	importStyle: 'umd'
 });
 


### PR DESCRIPTION
BREAKING CHANGE: Drop support for generating node.js compatible
importStyle polyfill.  node.js targets can still be supported by letting
rollup output format handle the polyfill.

Fixes #3