### PR TITLE
Add `location` to import styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ const importStyles = {
 	iife: 'document.currentScript && document.currentScript.src || document.baseURI',
 	umd: 'document.currentScript && document.currentScript.src || document.baseURI',
 	system: 'module.meta.url',
-	baseURI: 'document.baseURI'
+	baseURI: 'document.baseURI',
+	location: 'self.location.href'
 };
 
 module.exports = () => ({

--- a/test.js
+++ b/test.js
@@ -131,3 +131,10 @@ test('importStyle system', babelTest, {
 	result: "const importMeta={url:new URL('./file.js',module.meta.url).href};console.log(importMeta.url);",
 	importStyle: 'system'
 });
+
+test('importStyle location', babelTest, {
+	source: 'console.log(import.meta.url);',
+	result: "const importMeta={url:new URL('./file.js',self.location.href).href};console.log(importMeta.url);",
+	importStyle: 'location'
+});
+


### PR DESCRIPTION
Uses `self` for worker context support.
I use the `baseURI` API in a script that runs in a worker thread, but for that purpose I had to shim the `document` because it is not available in a worker scope.
Also `self.location` executed in a worker scope is immutable.